### PR TITLE
Add new RPC funtionality for the new getstakeinfo wallet call

### DIFF
--- a/extensions.go
+++ b/extensions.go
@@ -102,15 +102,15 @@ func (c *Client) CreateEncryptedWallet(passphrase string) error {
 // of a FutureExistsAddressResultAsync RPC invocation (or an applicable error).
 type FutureExistsAddressResult chan *response
 
-// Receive waits for the response promised by the future and returns information
-// about all transactions associated with the provided addresses.
+// Receive waits for the response promised by the future and returns whether or
+// not an address exists in the blockchain or mempool.
 func (r FutureExistsAddressResult) Receive() (bool, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return false, err
 	}
 
-	// Unmarshal the result as an array of existsaddress object.
+	// Unmarshal the result as a bool.
 	var exists bool
 	err = json.Unmarshal(res, &exists)
 	if err != nil {
@@ -128,11 +128,96 @@ func (c *Client) ExistsAddressAsync(address dcrutil.Address) FutureExistsAddress
 }
 
 // ExistsAddress returns information about whether or not an address has been
-// used on the main chain.
+// used on the main chain or in mempool.
 //
 // NOTE: This is a dcrd extension.
 func (c *Client) ExistsAddress(address dcrutil.Address) (bool, error) {
 	return c.ExistsAddressAsync(address).Receive()
+}
+
+// FutureExistsLiveTicketResult is a future promise to deliver the result
+// of a FutureExistsLiveTicketResultAsync RPC invocation (or an
+// applicable error).
+type FutureExistsLiveTicketResult chan *response
+
+// Receive waits for the response promised by the future and returns whether
+// or not the ticket exists in the live ticket database.
+func (r FutureExistsLiveTicketResult) Receive() (bool, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return false, err
+	}
+
+	// Unmarshal the result as a bool.
+	var exists bool
+	err = json.Unmarshal(res, &exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// ExistsLiveTicketAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+func (c *Client) ExistsLiveTicketAsync(hash *chainhash.Hash) FutureExistsLiveTicketResult {
+	cmd := dcrjson.NewExistsLiveTicketCmd(hash.String())
+	return c.sendCmd(cmd)
+}
+
+// ExistsLiveTicket returns information about whether or not a ticket hash exists
+// in the live ticket database.
+//
+// NOTE: This is a dcrd extension.
+func (c *Client) ExistsLiveTicket(hash *chainhash.Hash) (bool, error) {
+	return c.ExistsLiveTicketAsync(hash).Receive()
+}
+
+// FutureMissedTicketsResult is a future promise to deliver the result
+// of a FutureMissedTicketsResultAsync RPC invocation (or an applicable error).
+type FutureMissedTicketsResult chan *response
+
+// Receive waits for the response promised by the future and returns all
+// currently missed tickets from the missed ticket database.
+func (r FutureMissedTicketsResult) Receive() ([]*chainhash.Hash, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the result as a bool.
+	var container dcrjson.MissedTicketsResult
+	err = json.Unmarshal(res, &container)
+	if err != nil {
+		return nil, err
+	}
+
+	missedTickets := make([]*chainhash.Hash, 0, len(container.Tickets))
+	for _, ticketStr := range container.Tickets {
+		h, err := chainhash.NewHashFromStr(ticketStr)
+		if err != nil {
+			return nil, err
+		}
+		missedTickets = append(missedTickets, h)
+	}
+
+	return missedTickets, nil
+}
+
+// MissedTicketsAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+func (c *Client) MissedTicketsAsync() FutureMissedTicketsResult {
+	cmd := dcrjson.NewMissedTicketsCmd()
+	return c.sendCmd(cmd)
+}
+
+// MissedTickets returns all currently missed tickets from the missed
+// ticket database in the daemon.
+//
+// NOTE: This is a dcrd extension.
+func (c *Client) MissedTickets() ([]*chainhash.Hash, error) {
+	return c.MissedTicketsAsync().Receive()
 }
 
 // FutureListAddressTransactionsResult is a future promise to deliver the result

--- a/wallet.go
+++ b/wallet.go
@@ -2721,6 +2721,44 @@ func (c *Client) GetInfo() (*dcrjson.InfoWalletResult, error) {
 	return c.GetInfoAsync().Receive()
 }
 
+// FutureGetStakeInfoResult is a future promise to deliver the result of a
+// GetStakeInfoAsync RPC invocation (or an applicable error).
+type FutureGetStakeInfoResult chan *response
+
+// Receive waits for the response promised by the future and returns the stake
+// info provided by the server.
+func (r FutureGetStakeInfoResult) Receive() (*dcrjson.GetStakeInfoResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal result as a getstakeinfo result object.
+	var infoRes dcrjson.GetStakeInfoResult
+	err = json.Unmarshal(res, &infoRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &infoRes, nil
+}
+
+// GetStakeInfoAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function
+// on the returned instance.
+//
+// See GetStakeInfo for the blocking version and more details.
+func (c *Client) GetStakeInfoAsync() FutureGetStakeInfoResult {
+	cmd := dcrjson.NewGetStakeInfoCmd()
+	return c.sendCmd(cmd)
+}
+
+// GetStakeInfo returns stake mining info from a given wallet. This includes
+// various statistics on tickets it owns and votes it has produced.
+func (c *Client) GetStakeInfo() (*dcrjson.GetStakeInfoResult, error) {
+	return c.GetStakeInfoAsync().Receive()
+}
+
 // FutureGetTicketVoteBitsResult is a future promise to deliver the result of a
 // GetTicketVoteBitsAsync RPC invocation (or an applicable error).
 type FutureGetTicketVoteBitsResult chan *response


### PR DESCRIPTION
This adds functionality required to support getstakeinfo as well as
the ability to call getstakeinfo itself. Two new wrappers for daemon
RPC functions, missedtickets and existsliveticket, have been added.
