### PR TITLE
Correct OutPoint struct bug

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -1616,6 +1616,7 @@ func newOutPointFromWire(op *wire.OutPoint) dcrjson.OutPoint {
 	return dcrjson.OutPoint{
 		Hash:  op.Hash.String(),
 		Index: op.Index,
+		Tree:  op.Tree,
 	}
 }
 


### PR DESCRIPTION
A bug caused the tree to not be declared when creating a new wire.OutPoint
struct.
