### PR TITLE
TravisCI: Update to latest configurations. (#76)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: go
 go:
-  - 1.4.3
   - 1.5.3
   - 1.6
 sudo: false
 before_install:
   - gotools=golang.org/x/tools
-  - if [ "$TRAVIS_GO_VERSION" = "release" ]; then gotools=code.google.com/p/go.tools; fi
 install:
   - go get -d -t -v ./...
   - go get -v $gotools/cmd/cover
-  - go get -v $gotools/cmd/vet
   - go get -v github.com/bradfitz/goimports
   - go get -v github.com/golang/lint/golint
 script:


### PR DESCRIPTION
This updates the Go versions using when running the TravisCI integration
tests to reflect the latest supported Go versions.

Also, the vet tool moved into the Go source tree as of Go 1.5.  Its previous
location in the x/tools repo was deprecated at that time and has now
been removed.

Finally, old tool path is no longer needed, so it has been removed.
