### PR TITLE
ListUnspent docs: default maxconf missing a 9 digit.

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -215,14 +215,14 @@ func (c *Client) ListUnspentMinMaxAddressesAsync(minConf, maxConf int, addrs []d
 
 // ListUnspent returns all unspent transaction outputs known to a wallet, using
 // the default number of minimum and maximum number of confirmations as a
-// filter (1 and 999999, respectively).
+// filter (1 and 9999999, respectively).
 func (c *Client) ListUnspent() ([]dcrjson.ListUnspentResult, error) {
 	return c.ListUnspentAsync().Receive()
 }
 
 // ListUnspentMin returns all unspent transaction outputs known to a wallet,
 // using the specified number of minimum conformations and default number of
-// maximum confiramtions (999999) as a filter.
+// maximum confiramtions (9999999) as a filter.
 func (c *Client) ListUnspentMin(minConf int) ([]dcrjson.ListUnspentResult, error) {
 	return c.ListUnspentMinAsync(minConf).Receive()
 }


### PR DESCRIPTION
The documentation for ListUnspent and ListUnspentMin both indicate 999999 as the default maxconf, but the default is 9999999 according to jsonrpcdefault in ListUnspentCmd:  https://github.com/decred/dcrd/blob/master/dcrjson/walletsvrcmds.go#L393
