### PR TITLE
Switch goclean to use metalinter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ install:
   - go get github.com/Masterminds/glide
   - glide install
   - go install
-  - go get -v golang.org/x/tools/cmd/cover
-  - go get -v github.com/bradfitz/goimports
-  - go get -v github.com/golang/lint/golint
+  - go get -v github.com/alecthomas/gometalinter
+  - gometalinter --install
 script:
   - export PATH=$PATH:$HOME/gopath/bin
   - ./goclean.sh

--- a/examples/dcrdwebsockets/main.go
+++ b/examples/dcrdwebsockets/main.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrutil"
 )
@@ -22,11 +21,11 @@ func main() {
 	// for notifications.  See the documentation of the dcrrpcclient
 	// NotificationHandlers type for more details about each handler.
 	ntfnHandlers := dcrrpcclient.NotificationHandlers{
-		OnBlockConnected: func(hash *chainhash.Hash, height int32, time time.Time, vb uint16) {
-			log.Printf("Block connected: %v (%d) %v %v", hash, height, time, vb)
+		OnBlockConnected: func(blockHeader []byte, transactions [][]byte) {
+			log.Printf("Block connected: %v %v", blockHeader, transactions)
 		},
-		OnBlockDisconnected: func(hash *chainhash.Hash, height int32, time time.Time, vb uint16) {
-			log.Printf("Block disconnected: %v (%d) %v %v", hash, height, time, vb)
+		OnBlockDisconnected: func(blockHeader []byte) {
+			log.Printf("Block disconnected: %v", blockHeader)
 		},
 	}
 

--- a/goclean.sh
+++ b/goclean.sh
@@ -6,33 +6,15 @@
 # 4. go vet        (http://golang.org/cmd/vet)
 # 5. test coverage (http://blog.golang.org/cover)
 
+# gometaling (github.com/alecthomas/gometalinter) is used to run each each
+# static checker.
+
 set -e
 
 # Automatic checks
-test -z "$(gofmt -l -w .     | tee /dev/stderr)"
-test -z "$(goimports -l -w . | tee /dev/stderr)"
-test -z "$(golint .          | tee /dev/stderr)"
-go vet ./...
-env GORACE="halt_on_error=1" go test -v -race ./...
-
-# Run test coverage on each subdirectories and merge the coverage profile.
-
-echo "mode: count" > profile.cov
-
-# Standard go tooling behavior is to ignore dirs with leading underscores.
-for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -type d);
-do
-if ls $dir/*.go &> /dev/null; then
-  go test -covermode=count -coverprofile=$dir/profile.tmp $dir
-  if [ -f $dir/profile.tmp ]; then
-    cat $dir/profile.tmp | tail -n +2 >> profile.cov
-    rm $dir/profile.tmp
-  fi
-fi
-done
-
-go tool cover -func profile.cov
-
-# To submit the test coverage result to coveralls.io,
-# use goveralls (https://github.com/mattn/goveralls)
-# goveralls -coverprofile=profile.cov -service=travis-ci
+test -z "$(gometalinter --disable-all \
+--enable=gofmt \
+--enable=golint \
+--enable=vet \
+--enable=goimports \
+--deadline=20s $(glide novendor) | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -562,7 +562,7 @@ func (c *Client) reregisterNtfns() error {
 // ignoreResends is a set of all methods for requests that are "long running"
 // are not be reissued by the client on reconnect.
 var ignoreResends = map[string]struct{}{
-	"rescan": struct{}{},
+	"rescan": {},
 }
 
 // resendRequests resends any requests that had not completed when the client


### PR DESCRIPTION
Fix issue caught by gofmt.

Update example code so it compiles again, also caught by
the goclean script.

Close #42