### PR TITLE
Add Go 1.8 support, remove Go 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.6.3
-  - 1.7.3
+  - 1.7.x
+  - 1.8.x
 sudo: false
 install:
   - go get github.com/Masterminds/glide


### PR DESCRIPTION
Go 1.8 is out and by policy we only support the latest two Go releases.