### PR TITLE
Improve HTTP error handling.

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -134,22 +134,47 @@ func (r FutureGetBlockVerboseResult) Receive() (*btcjson.GetBlockVerboseResult, 
 // the returned instance.
 //
 // See GetBlockVerbose for the blocking version and more details.
-func (c *Client) GetBlockVerboseAsync(blockHash *chainhash.Hash, verboseTx bool) FutureGetBlockVerboseResult {
+func (c *Client) GetBlockVerboseAsync(blockHash *chainhash.Hash) FutureGetBlockVerboseResult {
 	hash := ""
 	if blockHash != nil {
 		hash = blockHash.String()
 	}
 
-	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(true), &verboseTx)
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(true), nil)
 	return c.sendCmd(cmd)
 }
 
 // GetBlockVerbose returns a data structure from the server with information
 // about a block given its hash.
 //
+// See GetBlockVerboseTx to retrieve transaction data structures as well.
 // See GetBlock to retrieve a raw block instead.
-func (c *Client) GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*btcjson.GetBlockVerboseResult, error) {
-	return c.GetBlockVerboseAsync(blockHash, verboseTx).Receive()
+func (c *Client) GetBlockVerbose(blockHash *chainhash.Hash) (*btcjson.GetBlockVerboseResult, error) {
+	return c.GetBlockVerboseAsync(blockHash).Receive()
+}
+
+// GetBlockVerboseTxAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See GetBlockVerboseTx or the blocking version and more details.
+func (c *Client) GetBlockVerboseTxAsync(blockHash *chainhash.Hash) FutureGetBlockVerboseResult {
+	hash := ""
+	if blockHash != nil {
+		hash = blockHash.String()
+	}
+
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(true), btcjson.Bool(true))
+	return c.sendCmd(cmd)
+}
+
+// GetBlockVerboseTx returns a data structure from the server with information
+// about a block and its transactions given its hash.
+//
+// See GetBlockVerbose if only transaction hashes are preferred.
+// See GetBlock to retrieve a raw block instead.
+func (c *Client) GetBlockVerboseTx(blockHash *chainhash.Hash) (*btcjson.GetBlockVerboseResult, error) {
+	return c.GetBlockVerboseTxAsync(blockHash).Receive()
 }
 
 // FutureGetBlockCountResult is a future promise to deliver the result of a


### PR DESCRIPTION
Contain the following upstream commits:
- 6e5c0a79044d3d80a22d94049eeb509ea040efac
  - Reverted because it does not apply to Decred
- 2b780d16b042054d07aa322146194118fd7f7b81

---

This modifies the code which handles failed server responses to attempt to unmarshal the response bytes as a regular JSON-RPC response regardless of the HTTP status code and, if that fails, return an error that includes the status code as well as the raw response bytes.

This is being done because some JSON-RPC servers, don't follow the intended HTTP status code meanings.  For example, if you request a block that doesn't exist, it returns a status code of 500 which is supposed to mean internal server error instead of a standard 200 status code (since the HTTP request itself was successful) along with the JSON-RPC error response.

The result is that errors from these non-compliant RPC servers will now show up as an actual `RPCError` instead of an error with the raw JSON bytes.

This also has the benefit of returning the HTTP status code in the error for real HTTP failure cases such as 401 authentication failures, which previously would just be an empty error when used against a non-compliant RPC server since it doesn't return the actual response along with the status code as it should.
